### PR TITLE
Added basic Manila support and prerequisites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+.idea

--- a/cli.py
+++ b/cli.py
@@ -41,7 +41,7 @@ class Iridium(TerminalInteractiveShell):
 
     def raw_input(self, prompt=""):
         # TODO correct eof issue with custom prompt.
-        prompt = "iridium >>>"
+        prompt = "iridium >>> "
         return TerminalInteractiveShell.raw_input(self, prompt)
 
 
@@ -66,6 +66,7 @@ local_modules['heat_mod'] = stack_modules.import_mod('heat')
 local_modules['swift_mod'] = stack_modules.import_mod('swift')
 local_modules['glance_mod'] = stack_modules.import_mod('glance')
 local_modules['cinder_mod'] = stack_modules.import_mod('cinder')
+local_modules['manila_mod'] = stack_modules.import_mod('manila')
 local_modules['neutron_mod'] = stack_modules.import_mod('neutron')
 # TODO possibly another way to determine tracker platform.
 local_modules['tracker_mod'] = tracker_module.import_mod(config.bug_tracker['tracker'])

--- a/iridium/libs/openstack/manila.py
+++ b/iridium/libs/openstack/manila.py
@@ -1,0 +1,31 @@
+__author__  = 'Dustin Schoenbrun'
+__license__ = 'Apache License 2.0'
+__version__ = '0.1'
+__email__   = 'dschoenb@redhat.com'
+__status__  = 'Alpha'
+
+from keystoneclient.auth.identity import v2
+from keystoneclient import session
+from manilaclient import client
+from iridium.libs.openstack import keystone
+
+class ManilaBase(object):
+    """
+    ManilaBase is used for commands that can be issued to Manila.
+    """
+
+    def __init__(self, client_version, **kwargs):
+       """
+       Get the Keystone credentials and use them to create the Manila client.
+       :param client_version: The version of the Manila Client to use as a string (e.g. '2.0')
+       :param kwargs: Keystone authentication parameters. We need to have:
+            auth_url: The URL for Keystone Authentication
+            username: The username to use for Keystone authentication
+            password: The password for the user specified in username.
+            tenant_name: The name of the tenant that will be used for Keystone authentication
+       """
+       keystone_args = keystone.keystone_retrieve(**kwargs)
+       keystone_authorization = v2.Password(**keystone_args)
+       keystone_session = session.Session(auth=keystone_authorization)
+       self.manila_session = client.Client(client_version, session=keystone_session)
+

--- a/requirements
+++ b/requirements
@@ -7,6 +7,7 @@ python-neutronclient
 python-cinderclient
 python-swiftclient
 python-bugzilla
+python-manilaclient
 lauchpadlib
 python-jenkins
 gerritlib


### PR DESCRIPTION
This patch adds support for the creation of the basic Manila client
through the ManilaBase class. A basic gitignore was also added as
well as adding the loading of the Manila module. The requirements
file was also updated to include the Manila Client.